### PR TITLE
Version 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,6 @@ CommandUtilityは、Bukkitでのコマンド処理を改善するために開発
 
 注意: このライブラリはプラグインではないため、必ずshadeプラグインなどでjarファイル内に格納してください。  
 
-また、無ければKotlinを依存関係に追加してください。
-
-```kotlin
-// build.gradle.kts
-implementation("org.jetbrains.kotlin", "kotlin-stdlib-jdk8", "1.3.41")
-```
-
-```groovy
-// build.gradle
-implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.41'
-```
-
-```xml
-// pom.xml
-<dependency>
-    <groupId>org.jetbrains.kotlin</groupId>
-    <artifactId>kotlin-stdlib-jdk8</artifactId>
-    <version>1.3.41</version>
-</dependency>
-```
-
 ## 使用例
 
 [このリポジトリ](https://github.com/kuro46/CommandUtilityExample)を参照してください。

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,11 +18,10 @@ java {
 }
 
 repositories {
-    mavenLocal()
     jcenter()
     mavenCentral()
+    maven("https://dl.bintray.com/arrow-kt/arrow-kt/")
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
-    maven("https://oss.sonatype.org/content/repositories/snapshots")
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("io.gitlab.arturbosch.detekt") version "1.0.0-RC16"
     id("org.jlleitschuh.gradle.ktlint") version "8.1.0"
     id("org.jetbrains.dokka") version "0.9.18"
-    java
+    `java-library`
     maven
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.github.kuro46"
-version = "0.2.1"
+version = "0.3.0-SNAPSHOT"
 
 repositories {
     mavenLocal()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.github.kuro46"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,11 @@ plugins {
 group = "com.github.kuro46"
 version = "0.3.0-SNAPSHOT"
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 repositories {
     mavenLocal()
     jcenter()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,3 @@ tasks.test {
 tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
 }
-
-tasks.withType<Wrapper> {
-    distributionType = Wrapper.DistributionType.ALL
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ repositories {
 
 dependencies {
     compileOnly("org.bukkit", "bukkit", "1.12.2-R0.1-SNAPSHOT")
-    implementation(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib-jdk8"))
     implementation("io.arrow-kt", "arrow-core-data", "0.9.0")
     testImplementation("org.junit.jupiter", "junit-jupiter", "5.5.0")
 }

--- a/src/main/kotlin/com/github/kuro46/commandutility/CompletionUtils.kt
+++ b/src/main/kotlin/com/github/kuro46/commandutility/CompletionUtils.kt
@@ -16,3 +16,18 @@ fun <T> filterCandidates(
         .filter { it.startsWith(filterBy, ignoreCase) }
 }
 
+fun worldCandidates(filterBy: String): List<String> {
+    return filterCandidates(
+        Bukkit.getServer().worlds,
+        filterBy,
+        toStringFunc = { world -> world.name }
+    )
+}
+
+fun playerCandidates(filterBy: String): List<String> {
+    return filterCandidates(
+        Bukkit.getOnlinePlayers(),
+        filterBy,
+        toStringFunc = { player -> player.name }
+    )
+}

--- a/src/main/kotlin/com/github/kuro46/commandutility/CompletionUtils.kt
+++ b/src/main/kotlin/com/github/kuro46/commandutility/CompletionUtils.kt
@@ -1,0 +1,18 @@
+@file:JvmName("CompletionUtils")
+
+package com.github.kuro46.commandutility
+
+import org.bukkit.Bukkit
+
+@JvmOverloads
+fun <T> filterCandidates(
+    candidates: Iterable<T>,
+    filterBy: String,
+    ignoreCase: Boolean = true,
+    toStringFunc: (T) -> String = { it -> it.toString() }
+): List<String> {
+    return candidates
+        .map { toStringFunc(it) }
+        .filter { it.startsWith(filterBy, ignoreCase) }
+}
+

--- a/src/main/kotlin/com/github/kuro46/commandutility/handle/CommandManager.kt
+++ b/src/main/kotlin/com/github/kuro46/commandutility/handle/CommandManager.kt
@@ -97,7 +97,7 @@ abstract class CommandManager(
     }
 
     private fun getTreeByRawSections(rawSections: List<String>): CommandTree {
-        val sectionsToFind = CommandSections.fromStrings(rawSections)
+        val sectionsToFind = CommandSections.fromStringSections(rawSections)
         return when (val treeEntry = commandTree.findTree(sectionsToFind)) {
             is CommandTreeRoot -> throw IllegalArgumentException(
                 "'$sectionsToFind' has not registered yet."
@@ -155,7 +155,7 @@ abstract class CommandManager(
             getCandidatesByHandler(sender, rawSections, args, command)
         } else {
             val completing = args.lastOrNull() ?: ""
-            getCandidatesByTree(CommandSections.fromStrings(rawSections), completing)
+            getCandidatesByTree(CommandSections.fromStringSections(rawSections), completing)
         }
     }
 

--- a/src/main/kotlin/com/github/kuro46/commandutility/handle/CommandSections.kt
+++ b/src/main/kotlin/com/github/kuro46/commandutility/handle/CommandSections.kt
@@ -46,5 +46,10 @@ data class CommandSections(
         fun fromStringSections(strings: Iterable<String>): CommandSections {
             return CommandSections(strings.map { CommandSection(it) })
         }
+
+        @JvmStatic
+        fun fromString(string: String): CommandSections {
+            return fromStringSections(string.split(" "))
+        }
     }
 }

--- a/src/main/kotlin/com/github/kuro46/commandutility/handle/CommandSections.kt
+++ b/src/main/kotlin/com/github/kuro46/commandutility/handle/CommandSections.kt
@@ -43,7 +43,7 @@ data class CommandSections(
     companion object {
 
         @JvmStatic
-        fun fromStrings(strings: Iterable<String>): CommandSections {
+        fun fromStringSections(strings: Iterable<String>): CommandSections {
             return CommandSections(strings.map { CommandSection(it) })
         }
     }

--- a/src/main/kotlin/com/github/kuro46/commandutility/syntax/CommandSyntax.kt
+++ b/src/main/kotlin/com/github/kuro46/commandutility/syntax/CommandSyntax.kt
@@ -64,7 +64,7 @@ class CommandSyntax(
             val name = arguments.getOrNull(argsWithoutSpace.lastIndex)
                 ?.name
                 ?: arguments.last().name
-            val value = argsWithoutSpace.last()
+            val value = parsed.getValue(name)
             CompletingArgument(name, value)
         } else null
 


### PR DESCRIPTION
**Breaking changes:**

- Renamed from `CommandSections.fromStrings` to `fromStringSections`

*Changes:*

- Added [convenience method](https://github.com/kuro46/CommandUtility/blob/fcaf4e88181dff381a9179c7341ac8ccfabddbda/src/main/kotlin/com/github/kuro46/commandutility/handle/CommandSections.kt#L46) for create CommandSections from String (#11)
- Added [utility class](https://github.com/kuro46/CommandUtility/blob/fcaf4e88181dff381a9179c7341ac8ccfabddbda/src/main/kotlin/com/github/kuro46/commandutility/CompletionUtils.kt#L8) for filter candidates (#9)
- Added some [functions](https://github.com/kuro46/CommandUtility/blob/fcaf4e88181dff381a9179c7341ac8ccfabddbda/src/main/kotlin/com/github/kuro46/commandutility/CompletionUtils.kt#L19-L33) that returns candidates about frequently used things
- Improved HelpCommandHandler (eeb2afe, bbc6a59, ab485aa)
- Fixed issue of `CommandSyntax#parseCompleting` (#14)
- Declared kotlin-stdlib as `api`. You don't need adding `kotlin-stdlib` as a dependency from now on